### PR TITLE
[Improvement] Add code to check whether the course mapping added is valid

### DIFF
--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -20,10 +20,12 @@ import static seedu.exchangecoursemapper.constants.JsonKey.COURSES_ARRAY_LABEL;
 import static seedu.exchangecoursemapper.constants.Logs.ADD_NEW_COURSE_MAPPING;
 import static seedu.exchangecoursemapper.constants.Messages.LINE_SEPARATOR;
 import static seedu.exchangecoursemapper.constants.Messages.LIST_RELEVANT_PU;
+import static seedu.exchangecoursemapper.constants.Logs.INVALID_UNIVERSITY_INPUT;
 
 public class AddCoursesCommand extends PersonalTrackerCommand {
 
     private static final Logger logger = Logger.getLogger(AddCoursesCommand.class.getName());
+
 
     private static boolean isValidCourseMapping(String nusCourseInput, String puCourseInput,
                                                 JsonArray courses, String pu) {
@@ -71,7 +73,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         if (matchPu != null) {
             courses = jsonObject.getJsonObject(matchPu).getJsonArray(COURSES_ARRAY_LABEL);
         } else {
-            System.out.println("Invalid university input!");
+            System.out.println(INVALID_UNIVERSITY_INPUT);
             System.out.println(LINE_SEPARATOR);
             System.out.println(LIST_RELEVANT_PU);
             System.out.println(LINE_SEPARATOR);
@@ -83,7 +85,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
     @Override
     public void execute(String userInput, Storage storage) {
         try {
-            JsonObject jsonObject = super.createJsonObject();      //to add to isValidInputChecker
+            JsonObject jsonObject = super.createJsonObject();
             logger.log(Level.INFO, Logs.TRIM_STRING);
             String description = trimString(userInput);
             logger.log(Level.INFO, Logs.PARSE_ADD_COMMANDS);
@@ -157,7 +159,8 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         System.out.println("You have successfully added the course: " + addCourse.formatOutput());
     }
 
-    public boolean isValidInput(String nusCourseInput, String pu, String puCourseInput, JsonObject jsonObject) {
+    public boolean isValidInput(String nusCourseInput, String pu,
+                                String puCourseInput, JsonObject jsonObject) {
         JsonArray courses = getPUCourseList(pu, jsonObject);
         if (courses == null) {
             return false;

--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -12,8 +12,14 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static seedu.exchangecoursemapper.constants.JsonKey.*;
-
+import static seedu.exchangecoursemapper.constants.JsonKey.PU_COURSE_CODE_KEY;
+import static seedu.exchangecoursemapper.constants.JsonKey.NUS_COURSE_CODE_KEY;
+import static seedu.exchangecoursemapper.constants.JsonKey.PU_COURSE_NAME_KEY;
+import static seedu.exchangecoursemapper.constants.JsonKey.NUS_COURSE_NAME_KEY;
+import static seedu.exchangecoursemapper.constants.JsonKey.COURSES_ARRAY_LABEL;
+import static seedu.exchangecoursemapper.constants.Logs.ADD_NEW_COURSE_MAPPING;
+import static seedu.exchangecoursemapper.constants.Messages.LINE_SEPARATOR;
+import static seedu.exchangecoursemapper.constants.Messages.LIST_RELEVANT_PU;
 
 public class AddCoursesCommand extends PersonalTrackerCommand {
 
@@ -38,7 +44,9 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
     }
 
     private static void displayAvailableMappings(JsonArray courses,String pu) {
-        System.out.println("The available mappings for " + pu + " are :");
+        System.out.println("The available mappings for " + pu + " are:");
+        System.out.println(LINE_SEPARATOR);
+
         for (int i = 0; i < courses.size(); i++) {
             JsonObject course = courses.getJsonObject(i);
             String puCourseCode = course.getString(PU_COURSE_CODE_KEY).toLowerCase();
@@ -46,19 +54,27 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
             String nusCourseName = course.getString(NUS_COURSE_NAME_KEY).toLowerCase();
             String puCourseName = course.getString(PU_COURSE_NAME_KEY).toLowerCase();
 
-            System.out.println();
-            System.out.println(nusCourseCode + " " + nusCourseName + " | " + puCourseCode + " " + puCourseName);
+            System.out.println(nusCourseCode + " " + nusCourseName + " | "
+                    + puCourseCode + " " + puCourseName + System.lineSeparator());
         }
+        System.out.println(LINE_SEPARATOR);
     }
 
     private static JsonArray getPUCourseList(String pu, JsonObject jsonObject) {
         JsonArray courses;
-        String matchPu = jsonObject.keySet().stream().filter(key -> key.equalsIgnoreCase(pu)).findFirst().orElse(null);
+        String matchPu = jsonObject.keySet()
+                .stream()
+                .filter(key -> key.equalsIgnoreCase(pu))
+                .findFirst()
+                .orElse(null);
 
         if (matchPu != null) {
             courses = jsonObject.getJsonObject(matchPu).getJsonArray(COURSES_ARRAY_LABEL);
         } else {
             System.out.println("Invalid university input!");
+            System.out.println(LINE_SEPARATOR);
+            System.out.println(LIST_RELEVANT_PU);
+            System.out.println(LINE_SEPARATOR);
             return null;
         }
         return courses;
@@ -87,7 +103,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
                 storage.addCourse(courseToStore);
                 printAddMessage(courseToStore);
             } else {
-                System.out.println("Please add a new course mapping!");
+                System.out.println(ADD_NEW_COURSE_MAPPING);
             }
 
         } catch (IllegalArgumentException | IOException e) {

--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -106,7 +106,6 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         }
 
         JsonArray courses = jsonObject.getJsonObject(pu).getJsonArray(COURSES_ARRAY_LABEL);
-
         for (int i = 0; i < courses.size(); i++) {
             JsonObject course = courses.getJsonObject(i);
             String puCourseCode = course.getString(PU_COURSE_CODE_KEY).toLowerCase();

--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -19,7 +19,8 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
 
     private static final Logger logger = Logger.getLogger(AddCoursesCommand.class.getName());
 
-    private static boolean isValidCourseMapping(String nusCourseInput, String puCourseInput, JsonArray courses) {
+    private static boolean isValidCourseMapping(String nusCourseInput, String puCourseInput,
+                                                JsonArray courses, String pu) {
         for (int i = 0; i < courses.size(); i++) {
             JsonObject course = courses.getJsonObject(i);
             String puCourseCode = course.getString(PU_COURSE_CODE_KEY).toLowerCase();
@@ -32,7 +33,22 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         }
 
         System.out.println("Invalid course mapping!");
+        displayAvailableMappings(courses,pu);
         return false;
+    }
+
+    private static void displayAvailableMappings(JsonArray courses,String pu) {
+        System.out.println("The available mappings for " + pu + " are :");
+        for (int i = 0; i < courses.size(); i++) {
+            JsonObject course = courses.getJsonObject(i);
+            String puCourseCode = course.getString(PU_COURSE_CODE_KEY).toLowerCase();
+            String nusCourseCode = course.getString(NUS_COURSE_CODE_KEY).toLowerCase();
+            String nusCourseName = course.getString(NUS_COURSE_NAME_KEY).toLowerCase();
+            String puCourseName = course.getString(PU_COURSE_NAME_KEY).toLowerCase();
+
+            System.out.println();
+            System.out.println(nusCourseCode + " " + nusCourseName + " | " + puCourseCode + " " + puCourseName);
+        }
     }
 
     private static JsonArray getPUCourseList(String pu, JsonObject jsonObject) {
@@ -42,7 +58,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         if (matchPu != null) {
             courses = jsonObject.getJsonObject(matchPu).getJsonArray(COURSES_ARRAY_LABEL);
         } else {
-            System.out.println("Invalid university input");
+            System.out.println("Invalid university input!");
             return null;
         }
         return courses;
@@ -130,6 +146,6 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
         if (courses == null) {
             return false;
         }
-        return isValidCourseMapping(nusCourseInput, puCourseInput, courses);
+        return isValidCourseMapping(nusCourseInput, puCourseInput, courses,pu);
     }
 }

--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -6,8 +6,15 @@ import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.exception.Exception;
 import seedu.exchangecoursemapper.constants.Assertions;
 
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.json.JsonObject;
+import javax.json.JsonArray;
+
+import static seedu.exchangecoursemapper.constants.JsonKey.COURSES_ARRAY_LABEL;
+import static seedu.exchangecoursemapper.constants.JsonKey.NUS_COURSE_CODE_KEY;
+import static seedu.exchangecoursemapper.constants.JsonKey.PU_COURSE_CODE_KEY;
 
 
 public class AddCoursesCommand extends PersonalTrackerCommand {
@@ -17,6 +24,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
     @Override
     public void execute(String userInput, Storage storage) {
         try {
+            JsonObject jsonObject = super.createJsonObject();      //to add to isValidInputChecker
             logger.log(Level.INFO, Logs.TRIM_STRING);
             String description = trimString(userInput);
             logger.log(Level.INFO, Logs.PARSE_ADD_COMMANDS);
@@ -27,6 +35,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
             String nusCourse = descriptionSubstrings[0].trim();
             String pu = descriptionSubstrings[1].trim();
             String puCourse = descriptionSubstrings[2].trim();
+            isValidInput(nusCourse,pu,puCourse,jsonObject);
 
 
             logger.log(Level.INFO, Logs.FORMAT);
@@ -35,7 +44,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
 
             printAddMessage(courseToStore);
 
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IOException e) {
             System.out.println(e.getMessage());
         }
     }
@@ -84,5 +93,36 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
 
     public void printAddMessage(Course addCourse) {
         System.out.println("You have successfully added the course: " + addCourse.formatOutput());
+    }
+
+    public boolean isValidInput(String nusCourseInput, String pu, String puCourseInput, JsonObject jsonObject){
+
+        boolean isPuValid = jsonObject.keySet().stream()
+                .anyMatch(key -> key.equalsIgnoreCase(pu));
+
+        if (!isPuValid){
+            System.out.println("Invalid University Input. The relevant universities are ");
+            return false;
+        }
+
+        JsonArray courses = jsonObject.getJsonObject(pu).getJsonArray(COURSES_ARRAY_LABEL);
+
+        for (int i = 0; i < courses.size(); i++) {
+            JsonObject course = courses.getJsonObject(i);
+            String puCourseCode = course.getString(PU_COURSE_CODE_KEY).toLowerCase();
+            String nusCourseCode = course.getString(NUS_COURSE_CODE_KEY).toLowerCase();
+
+            if (!nusCourseInput.equals(nusCourseCode)){
+                System.out.println("Invalid partner university course code!");
+                return false;
+            }
+
+            if (!puCourseInput.equals(puCourseCode)){
+                System.out.println("Invalid nus course code!");
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
@@ -25,7 +25,6 @@ public class Logs {
     public static final String PARSE_ADD_COMMANDS = "Check user input and split it into substrings.";
     public static final String EXTRACT_COURSES = "Extract from NUS course code, PU and PU course code from array.";
     public static final String FORMAT = "Format output";
-    public static final String ADD_TO_STORAGE = "Adding course to storage: ";
     public static final String MISSING_KEYWORDS = "Missing /pu or /coursepu keyword.";
     public static final String ADJACENT_KEYWORDS = "Adjacent keywords.";
     public static final String INVALID_COURSE_CODE = "Invalid course code or partner university.";
@@ -34,4 +33,5 @@ public class Logs {
     public static final String COMMAND_PARSED = "Command parsed successfully";
     public static final String INVALID_COMMAND = "Command is invalid.";
     public static final String EXECUTION_FAILED = "Command execution failed unexpectedly.";
+    public static final String ADD_NEW_COURSE_MAPPING = "Please add a new course mapping!";
 }

--- a/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
@@ -34,4 +34,5 @@ public class Logs {
     public static final String INVALID_COMMAND = "Command is invalid.";
     public static final String EXECUTION_FAILED = "Command execution failed unexpectedly.";
     public static final String ADD_NEW_COURSE_MAPPING = "Please add a new course mapping!";
+    public static final String INVALID_UNIVERSITY_INPUT = "Invalid university input!";
 }

--- a/src/main/java/seedu/exchangecoursemapper/constants/Messages.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Messages.java
@@ -5,4 +5,13 @@ public class Messages {
     public static final String NO_MAPPABLE_COURSES_MESSAGE = "No courses found for the given course code.";
     public static final String INVALID_COMMAND_MESSAGE = "Please provide a valid command!" +
             "\nType 'commands' to find out what we can help you with :)";
+    public static final String LIST_RELEVANT_PU = "The relevant universities are (non-case sensitive):\n" +
+            "1. Chulalongkorn University\n" +
+            "2. The University of Melbourne\n" +
+            "3.The Australian National University\n" +
+            "4. Victoria University of Wellington\n" +
+            "5.The University of Western Australia\n\n" +
+            "NOTE: Please indicate the partner universities FULL NAME!\n" +
+            "NOTE: Instead of \"Australian National University,\" " +
+            "please indicate \"The Australian National University.\"";
 }

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -9,6 +9,7 @@ import seedu.exchangecoursemapper.command.DeleteCoursesCommand;
 import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.ui.UI;
 
+
 import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -74,4 +75,5 @@ public class Parser {
             System.out.println(INVALID_COMMAND_MESSAGE);
         }
     }
+
 }


### PR DESCRIPTION
Fixes #61 

Conduct error checking when users add course mappings. It would throw an error in these scenarios: 

1. The partner university added is not in the database (NTU, SMU) etc.
2. Invalid course mapping. For instance, the user tried to map NUS CS2102 Database Systems to 
   The University of Melbourne COMP90024 Cluster and Cloud Computing.
3. Incorrect spelling for partner universities and course codes. 


