### PR TITLE
[Improvement] Add ListMappedModulesCommand to display all mapped modules

### DIFF
--- a/src/main/java/seedu/exchangecoursemapper/command/ListPersonalTrackerCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/ListPersonalTrackerCommand.java
@@ -1,0 +1,33 @@
+package seedu.exchangecoursemapper.command;
+
+import seedu.exchangecoursemapper.storage.Storage;
+
+import java.util.List;
+
+import static seedu.exchangecoursemapper.constants.Messages.LINE_SEPARATOR;
+
+public class ListPersonalTrackerCommand extends Command {
+
+    private final Storage storage;
+
+    public ListPersonalTrackerCommand(Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public void execute(String userInput) {
+        List<String> mappedModules = storage.loadAllCourses();
+
+        if (mappedModules.isEmpty()) {
+            System.out.println("No modules mapped yet.");
+        } else {
+            System.out.println("Mapped Modules:");
+            System.out.println(LINE_SEPARATOR);
+            for (String module : mappedModules) {
+                System.out.println(module);
+            }
+            System.out.println(LINE_SEPARATOR);
+        }
+    }
+}
+

--- a/src/main/java/seedu/exchangecoursemapper/constants/Commands.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Commands.java
@@ -10,6 +10,7 @@ public class Commands {
     public static final String BYE = "bye";
     public static final String LISTINGSCHOOLS = "list schools";
     public static final String OBTAIN = "obtain";
+    public static final String LIST_MAPPED = "list mapped";
     public static final int COMMAND_WORD_INDEX = 0;
     public static final int PLAN_INDEX_TO_DELETE = 1;
     public static final int FILTER_COURSES_MAX_ARGS = 2;

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -8,6 +8,7 @@ import seedu.exchangecoursemapper.command.AddCoursesCommand;
 import seedu.exchangecoursemapper.command.HelpCommand;
 import seedu.exchangecoursemapper.command.DeleteCoursesCommand;
 import seedu.exchangecoursemapper.command.ObtainContactsCommand;
+import seedu.exchangecoursemapper.command.ListPersonalTrackerCommand;
 import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.ui.UI;
 
@@ -26,6 +27,7 @@ import static seedu.exchangecoursemapper.constants.Commands.OBTAIN;
 import static seedu.exchangecoursemapper.constants.Commands.LISTINGSCHOOLS;
 import static seedu.exchangecoursemapper.constants.Commands.COMMAND_WORD_INDEX;
 import static seedu.exchangecoursemapper.constants.Commands.HELP;
+import static seedu.exchangecoursemapper.constants.Commands.LIST_MAPPED;
 import static seedu.exchangecoursemapper.constants.Logs.RECEIVED_INPUT;
 import static seedu.exchangecoursemapper.constants.Logs.NULL_INPUT;
 import static seedu.exchangecoursemapper.constants.Logs.EMPTY_INPUT_DETAILS;
@@ -48,7 +50,7 @@ public class Parser {
     public void processUserInput(String userInput, Storage storage) {
         assert userInput != null : NULL_INPUT;
 
-        String input = userInput.trim();
+        String input = userInput.trim().toLowerCase();
         String[] inputDetails = input.split(SPACE);
 
         logger.log(Level.INFO, RECEIVED_INPUT, input);
@@ -73,6 +75,8 @@ public class Parser {
             new HelpCommand().execute(input);
         } else if (command.equals(OBTAIN)) {
             new ObtainContactsCommand().execute(input);
+        } else if (input.equals(LIST_MAPPED)) {
+            new ListPersonalTrackerCommand(storage).execute(input);
         } else if (command.equals(BYE)) {
             mapperUI.displayExitMessage();
         } else {


### PR DESCRIPTION
- Implemented command to list all mapped modules in the format 'NUS Course | PU | PU Course'.
- Integrated the command with the parser under 'list modules' command.
- Allows users to view all saved course mappings in myList.json on the CLI.

Fixes #117 