### PR TITLE
[Bug Fix] Add error handling to FilterCoursesCommand

### DIFF
--- a/src/main/java/seedu/exchangecoursemapper/command/FilterCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/FilterCoursesCommand.java
@@ -63,7 +63,10 @@ public class FilterCoursesCommand extends CheckInformationCommand {
             displayMappableCourses(jsonObject, courseToFind.toLowerCase());
         } catch (IOException e) {
             logger.log(Level.WARNING, FAILURE_READ_JSON_FILE);
-            System.err.println(Exception.fileReadError());
+            System.out.println(Exception.fileReadError());
+        } catch (IllegalArgumentException e) {
+            logger.log(Level.WARNING, e.getMessage());
+            System.out.println(e.getMessage());
         }
         logger.log(Level.INFO, COMPLETE_EXECUTION);
     }
@@ -74,7 +77,7 @@ public class FilterCoursesCommand extends CheckInformationCommand {
      * @param userInput A String containing the user's input.
      * @return a String containing the extracted information: NUS course code.
      */
-    public String getNusCourseCode(String userInput) {
+    public String getNusCourseCode(String userInput) throws IllegalArgumentException {
         String input = userInput.trim().replaceAll(REPEATED_SPACES, SPACE);
         String[] inputDetails = input.split(SPACE);
         if (inputDetails.length == COMMAND_WORD_INDEX + ZERO_INDEX_OFFSET) {

--- a/src/test/java/seedu/exchangecoursemapper/FilterCoursesCommandTest.java
+++ b/src/test/java/seedu/exchangecoursemapper/FilterCoursesCommandTest.java
@@ -45,9 +45,7 @@ public class FilterCoursesCommandTest {
 
     @Test
     public void displayMappableCourses_mappableNusCourse_expectMappableCoursesList() throws FileNotFoundException {
-        JsonReader jsonReader = Json.createReader(new FileReader("./data/database.json"));
-        JsonObject jsonObject = jsonReader.readObject();
-        jsonReader.close();
+        JsonObject jsonObject = createDatabaseJsonObject();
 
         String nusCourseCode = "cs3244";
         filterCoursesCommand.displayMappableCourses(jsonObject, nusCourseCode);
@@ -72,9 +70,7 @@ public class FilterCoursesCommandTest {
     @Test
     public void displayMappableCourses_mappableNusCourseInUpperCase_expectMappableCoursesList()
             throws FileNotFoundException {
-        JsonReader jsonReader = Json.createReader(new FileReader("./data/database.json"));
-        JsonObject jsonObject = jsonReader.readObject();
-        jsonReader.close();
+        JsonObject jsonObject = createDatabaseJsonObject();
 
         String nusCourseCode = "CS3244";
         filterCoursesCommand.displayMappableCourses(jsonObject, nusCourseCode);
@@ -98,14 +94,10 @@ public class FilterCoursesCommandTest {
 
     @Test
     public void displayMappableCourses_nonMappableNusCourse_expectNoMappableCourses() throws FileNotFoundException {
-        JsonReader jsonReader = Json.createReader(new FileReader("./data/database.json"));
-        JsonObject jsonObject = jsonReader.readObject();
-        jsonReader.close();
+        JsonObject jsonObject = createDatabaseJsonObject();
 
         String nusCourseCode = "ee2026";
-
         filterCoursesCommand.displayMappableCourses(jsonObject, nusCourseCode);
-
         String actualOutput = outputStreamCaptor.toString();
         assertEquals("No courses found for the given course code.",
                 normalizeLineEndings(actualOutput));
@@ -114,14 +106,10 @@ public class FilterCoursesCommandTest {
     @Test
     public void displayMappableCourses_nonMappableNusCourseInUpperCase_expectNoMappableCourses()
             throws FileNotFoundException {
-        JsonReader jsonReader = Json.createReader(new FileReader("./data/database.json"));
-        JsonObject jsonObject = jsonReader.readObject();
-        jsonReader.close();
+        JsonObject jsonObject = createDatabaseJsonObject();
 
         String nusCourseCode = "EE2026";
-
         filterCoursesCommand.displayMappableCourses(jsonObject, nusCourseCode);
-
         String actualOutput = outputStreamCaptor.toString();
         assertEquals("No courses found for the given course code.",
                 normalizeLineEndings(actualOutput));
@@ -130,7 +118,6 @@ public class FilterCoursesCommandTest {
     @Test
     public void execute_oneNusCourseCode_expectMappableCoursesList() {
         String input = "filter CS3241";
-
         filterCoursesCommand.execute(input);
         String expectedOutput = """
                 Partner University: The University of Melbourne
@@ -145,17 +132,22 @@ public class FilterCoursesCommandTest {
     }
 
     @Test
-    public void execute_twoNusCourseCodes_expectException() {
+    public void execute_twoNusCourseCodes_expectErrorMessage() {
         String userInput = "filter CS3241 Ee2026";
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
-            filterCoursesCommand.execute(userInput);
-        });
+        filterCoursesCommand.execute(userInput);
+        String actualOutput = outputStreamCaptor.toString();
         assertEquals("Please note that we can only filter for only one NUS Course!",
-                e.getMessage());
+                normalizeLineEndings(actualOutput));
+    }
+
+    public JsonObject createDatabaseJsonObject() throws FileNotFoundException {
+        JsonReader jsonReader = Json.createReader(new FileReader("./data/database.json"));
+        JsonObject jsonObject = jsonReader.readObject();
+        jsonReader.close();
+        return jsonObject;
     }
 
     String normalizeLineEndings(String input) {
         return input.replaceAll("\\r\\n", "\n").replaceAll("\\r", "\n").trim();
     }
-
 }


### PR DESCRIPTION
Fixes #157 

- Added a catch block that catches and handles the IllegalArgumentException thrown by the `getNusCourseCode()` function.
- Modified JUnit tests accordingly.