### PR TITLE
Add method to parse university abbreviations

### DIFF
--- a/data/myList.json
+++ b/data/myList.json
@@ -1,8 +1,0 @@
-cs2102 | The University of Melbourne | info20003
-cs2102 | The University of Melbourne | info20003
-cs3244 | The Australian National University | comp3670
-cs3244 | The Australian National University | comp3670
-cs3244 | The Australian National University | comp3670
-cs2102 | victoria university of wellington | info151
-cs2102 | victoria university of wellington | info151
-cs2102 | Victoria University of Wellington | info151

--- a/data/myList.json
+++ b/data/myList.json
@@ -1,0 +1,8 @@
+cs2102 | The University of Melbourne | info20003
+cs2102 | The University of Melbourne | info20003
+cs3244 | The Australian National University | comp3670
+cs3244 | The Australian National University | comp3670
+cs3244 | The Australian National University | comp3670
+cs2102 | victoria university of wellington | info151
+cs2102 | victoria university of wellington | info151
+cs2102 | Victoria University of Wellington | info151

--- a/src/main/java/seedu/exchangecoursemapper/ExchangeCourseMapper.java
+++ b/src/main/java/seedu/exchangecoursemapper/ExchangeCourseMapper.java
@@ -8,6 +8,7 @@ public class ExchangeCourseMapper {
     /**
      * Main entry-point for the java.duke.Duke application.
      */
+
     private static Storage savedCourses;
 
     public static void main(String[] args) {

--- a/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
+++ b/src/main/java/seedu/exchangecoursemapper/command/AddCoursesCommand.java
@@ -8,6 +8,7 @@ import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.storage.CourseRepository;
 import seedu.exchangecoursemapper.parser.CourseValidator;
 import seedu.exchangecoursemapper.ui.UI;
+import seedu.exchangecoursemapper.parser.Parser;
 
 import javax.json.JsonObject;
 import java.io.IOException;
@@ -21,12 +22,14 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
     private CourseValidator courseValidator;
     private CourseRepository courseRepository;
     private UI ui;
+    private Parser parser;
 
     /** constructor */
     public AddCoursesCommand() {
         courseValidator = new CourseValidator();
         ui = new UI();
         courseRepository = new CourseRepository();
+        parser = new Parser();
     }
 
     /**
@@ -60,6 +63,7 @@ public class AddCoursesCommand extends PersonalTrackerCommand {
             logger.log(Level.INFO, Logs.EXTRACT_COURSES);
             String nusCourse = descriptionSubstrings[0].trim().toLowerCase();
             String pu = descriptionSubstrings[1].trim().toLowerCase();
+            pu = parser.parsePUAbbreviations(pu);
             String puCourse = descriptionSubstrings[2].trim().toLowerCase();
 
             logger.log(Level.INFO, Logs.FORMAT);

--- a/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Logs.java
@@ -105,4 +105,12 @@ public class Logs {
     public static final String APPEND_LINE = "Appended line to file: {0}";
     public static final String APPEND_LINE_FAIL = "Failed to append line to file";
 
+    public static final String THE_UNIVERSITY_OF_WESTERN_AUSTRALIA_ABBREVIATION = "uwa";
+    public static final String THE_UNIVERSITY_OF_WESTERN_AUSTRALIA = "The University of Western Australia";
+    public static final String THE_UNIVERSITY_OF_MELBOURNE_ABBREVIATION = "unimelb";
+    public static final String THE_UNIVERSITY_OF_MELBOURNE = "The University of Melbourne";
+    public static final String THE_AUSTRALIAN_NATIONAL_UNIVERSITY_ABBREVIATION = "anu";
+    public static final String THE_AUSTRALIAN_NATIONAL_UNIVERSITY = "The Australian National University";
+    public static final String VICTORIA_UNIVERSITY_OF_WELLINGTON_ABBREVIATION = "wgtn";
+    public static final String VICTORIA_UNIVERSITY_OF_WELLINGTON = "Victoria University of Wellington";
 }

--- a/src/main/java/seedu/exchangecoursemapper/constants/Messages.java
+++ b/src/main/java/seedu/exchangecoursemapper/constants/Messages.java
@@ -18,14 +18,15 @@ public class Messages {
     /* Messages for DeleteCoursesCommand */
     public static final String DELETE_COURSE_PLAN_HEADER = "You have deleted the course from your plan: ";
 
+
     public static final String LIST_RELEVANT_PU = "The relevant universities are (non-case sensitive):\n" +
-            "1. The University of Melbourne\n" +
-            "2.The Australian National University\n" +
-            "3. Victoria University of Wellington\n" +
-            "4.The University of Western Australia\n\n" +
-            "NOTE: Please indicate the partner universities FULL NAME!\n" +
-            "NOTE: Instead of \"Australian National University,\" " +
-            "please indicate \"The Australian National University.\"";
+            "1. The University of Melbourne - unimelb \n" +
+            "2.The Australian National University - anu\n" +
+            "3. Victoria University of Wellington - wgtn\n" +
+            "4.The University of Western Australia - uwa\n\n" +
+            "NOTE: Please indicate the partner universities FULL NAME or their respective " +
+            "official abbreviation.\n";
+
     public static final String COMMANDS_LIST =
             """
                     Here are the available commands:

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -11,6 +11,7 @@ import seedu.exchangecoursemapper.command.ObtainContactsCommand;
 import seedu.exchangecoursemapper.command.ListPersonalTrackerCommand;
 import seedu.exchangecoursemapper.command.CompareMappedCommand;
 import seedu.exchangecoursemapper.command.FindCoursesCommand;
+import seedu.exchangecoursemapper.constants.Logs;
 import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.ui.UI;
 
@@ -37,6 +38,16 @@ import static seedu.exchangecoursemapper.constants.Logs.EMPTY_INPUT_DETAILS;
 import static seedu.exchangecoursemapper.constants.Logs.INVALID_INPUT;
 import static seedu.exchangecoursemapper.constants.Messages.INVALID_COMMAND_MESSAGE;
 import static seedu.exchangecoursemapper.constants.Regex.SPACE;
+
+import static seedu.exchangecoursemapper.constants.Logs.THE_AUSTRALIAN_NATIONAL_UNIVERSITY;
+import static seedu.exchangecoursemapper.constants.Logs.THE_AUSTRALIAN_NATIONAL_UNIVERSITY_ABBREVIATION;
+import static seedu.exchangecoursemapper.constants.Logs.THE_UNIVERSITY_OF_WESTERN_AUSTRALIA_ABBREVIATION ;
+import static seedu.exchangecoursemapper.constants.Logs.THE_UNIVERSITY_OF_WESTERN_AUSTRALIA;
+import static seedu.exchangecoursemapper.constants.Logs.THE_UNIVERSITY_OF_MELBOURNE_ABBREVIATION;
+import static seedu.exchangecoursemapper.constants.Logs.THE_UNIVERSITY_OF_MELBOURNE;
+import static seedu.exchangecoursemapper.constants.Logs.VICTORIA_UNIVERSITY_OF_WELLINGTON_ABBREVIATION;
+import static seedu.exchangecoursemapper.constants.Logs.VICTORIA_UNIVERSITY_OF_WELLINGTON;
+
 
 public class Parser {
 
@@ -92,7 +103,6 @@ public class Parser {
         }
     }
 
-
     /**
      * Parses an abbreviated partner university name and returns the full name.
      *
@@ -102,14 +112,14 @@ public class Parser {
      */
     public String parsePUAbbreviations(String Pu) {
         String formattedPU = Pu.toLowerCase().trim();
-        if (formattedPU.equals("uwa")) {
-            formattedPU = "The University of Western Australia";
-        } else if (formattedPU.equals("unimelb")) {
-            formattedPU = "The University of Melbourne";
-        } else if (formattedPU.equals("anu")) {
-            formattedPU = "The Australian National University";
-        } else if (formattedPU.equals("wgtn")) {
-            formattedPU = "Victoria University of Wellington";
+        if (formattedPU.equals(THE_UNIVERSITY_OF_WESTERN_AUSTRALIA_ABBREVIATION)) {
+            formattedPU = THE_UNIVERSITY_OF_WESTERN_AUSTRALIA;
+        } else if (formattedPU.equals(THE_UNIVERSITY_OF_MELBOURNE_ABBREVIATION)) {
+            formattedPU = THE_UNIVERSITY_OF_MELBOURNE;
+        } else if (formattedPU.equals(THE_AUSTRALIAN_NATIONAL_UNIVERSITY_ABBREVIATION)) {
+            formattedPU = THE_AUSTRALIAN_NATIONAL_UNIVERSITY;
+        } else if (formattedPU.equals(VICTORIA_UNIVERSITY_OF_WELLINGTON_ABBREVIATION)) {
+            formattedPU = VICTORIA_UNIVERSITY_OF_WELLINGTON;
         }
         return formattedPU;
     }

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -60,7 +60,7 @@ public class Parser {
     public String getUserInput() {
         return scanner.nextLine();
     }
-    
+
     public void processUserInput(String userInput, Storage storage) {
         assert userInput != null : NULL_INPUT;
 

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -11,7 +11,6 @@ import seedu.exchangecoursemapper.command.ObtainContactsCommand;
 import seedu.exchangecoursemapper.command.ListPersonalTrackerCommand;
 import seedu.exchangecoursemapper.command.CompareMappedCommand;
 import seedu.exchangecoursemapper.command.FindCoursesCommand;
-import seedu.exchangecoursemapper.constants.Logs;
 import seedu.exchangecoursemapper.storage.Storage;
 import seedu.exchangecoursemapper.ui.UI;
 
@@ -106,12 +105,13 @@ public class Parser {
     /**
      * Parses an abbreviated partner university name and returns the full name.
      *
-     * @param Pu User's partner university input.
+     * @param PU User's partner university input.
+     *
      * @return the full name of the partner university if it matches a known abbreviation.
      * It will return the original string if no match with the formatted abbreviation is found.
      */
-    public String parsePUAbbreviations(String Pu) {
-        String formattedPU = Pu.toLowerCase().trim();
+    public String parsePUAbbreviations(String PU) {
+        String formattedPU = PU.toLowerCase().trim();
         if (formattedPU.equals(THE_UNIVERSITY_OF_WESTERN_AUSTRALIA_ABBREVIATION)) {
             formattedPU = THE_UNIVERSITY_OF_WESTERN_AUSTRALIA;
         } else if (formattedPU.equals(THE_UNIVERSITY_OF_MELBOURNE_ABBREVIATION)) {

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -49,7 +49,7 @@ public class Parser {
     public String getUserInput() {
         return scanner.nextLine();
     }
-
+    
     public void processUserInput(String userInput, Storage storage) {
         assert userInput != null : NULL_INPUT;
 
@@ -90,5 +90,27 @@ public class Parser {
             logger.log(Level.WARNING, INVALID_INPUT, command);
             System.out.println(INVALID_COMMAND_MESSAGE);
         }
+    }
+
+
+    /**
+     * Parses an abbreviated partner university name and returns the full name.
+     *
+     * @param Pu User's partner university input.
+     * @return the full name of the partner university if it matches a known abbreviation.
+     * It will return the original string if no match with the formatted abbreviation is found.
+     */
+    public String parsePUAbbreviations(String Pu) {
+        String formattedPU = Pu.toLowerCase().trim();
+        if (formattedPU.equals("uwa")) {
+            formattedPU = "The University of Western Australia";
+        } else if (formattedPU.equals("unimelb")) {
+            formattedPU = "The University of Melbourne";
+        } else if (formattedPU.equals("anu")) {
+            formattedPU = "The Australian National University";
+        } else if (formattedPU.equals("wgtn")) {
+            formattedPU = "Victoria University of Wellington";
+        }
+        return formattedPU;
     }
 }

--- a/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
+++ b/src/main/java/seedu/exchangecoursemapper/parser/Parser.java
@@ -104,11 +104,11 @@ public class Parser {
 
     /**
      * Parses an abbreviated partner university name and returns the full name.
+     * It will return the original string if no match with the formatted abbreviation is found.
      *
      * @param PU User's partner university input.
      *
      * @return the full name of the partner university if it matches a known abbreviation.
-     * It will return the original string if no match with the formatted abbreviation is found.
      */
     public String parsePUAbbreviations(String PU) {
         String formattedPU = PU.toLowerCase().trim();


### PR DESCRIPTION
Users can now type the official university abbreviations instead of the full university name when indicating their partner university of choice.

Fixes #306



